### PR TITLE
Ignore HTML comments and markdown links

### DIFF
--- a/bin/markcop
+++ b/bin/markcop
@@ -88,7 +88,8 @@ for line in $(git ls-files | grep '\.md$' | xargs grep -noP '[^\|].{80,}[^\|]$' 
   file_name=$(echo $line | cut -f1)
   line_num=$(echo $line | cut -f2)
   line_contents=$(echo $line | cut -f3)
-  if [[ ! $line_contents =~ ^.*$URL_REGEX.*$ ]]; then
+  # Check to make sure it isn't a link or HTML comment
+  if [[ ! $line_contents =~ ^.*$URL_REGEX.*$ && ! $line_contents =~ ^.*\<!--.*--\>.*$ && ! $line_contents =~ ^(\ )*\[.*\]\(.*\)$ ]]; then
     long_line=true
     HAS_ERROR=true
     printf "${RED}x${NC}"

--- a/bin/markcop
+++ b/bin/markcop
@@ -89,7 +89,7 @@ for line in $(git ls-files | grep '\.md$' | xargs grep -noP '[^\|].{80,}[^\|]$' 
   line_num=$(echo $line | cut -f2)
   line_contents=$(echo $line | cut -f3)
   # Check to make sure it isn't a link or HTML comment
-  if [[ ! $line_contents =~ ^.*$URL_REGEX.*$ && ! $line_contents =~ ^.*\<!--.*--\>.*$ && ! $line_contents =~ ^(\ )*\[.*\]\(.*\)$ ]]; then
+  if [[ ! $line_contents =~ ^.*$URL_REGEX.*$ && ! $line_contents =~ ^.*\<!--.*--\>.*$ && ! $(echo $line_contents | grep -noP '^(\ )*\[.*\]\(.*\)\W*$') ]]; then
     long_line=true
     HAS_ERROR=true
     printf "${RED}x${NC}"


### PR DESCRIPTION
@zachlatta Would you please review and merge this?

We now ignore html comments `^.*\<!--.*--\>.*$` and potentially indented markdown links ~~`^(\ )*\[.*\]\(.*\)$`~~ `'^(\ )*\[.*\]\(.*\)\W*$'` when checking for lines over 80 chars

EDIT: Allow for punctuation after markdown links
