### PR TITLE
Fix ignoring HTML comments in line length test

### DIFF
--- a/bin/markcop
+++ b/bin/markcop
@@ -105,7 +105,7 @@ for line in $(git ls-files | grep '\.md$' | xargs grep -noP '[^\|].{80,}[^\|]$' 
   line_contents=$(echo $line | cut -f3)
 
   # Check to make sure the line doesn't contain a link or HTML comment
-  html_comment_regex='^\<!--.*--\>$'
+  html_comment_regex='^<!--.*-->$'
   markdown_link_at_end_of_line_regex='\[.*\]\(.*\)\W*$'
   if [[ ! $line_contents =~ $URL_REGEX && ! $line_contents =~ $html_comment_regex && ! $line_contents =~ $markdown_link_at_end_of_line_regex ]]; then
     long_line=true


### PR DESCRIPTION
The bug that this fixes causes the tests to fail in hackedu/meta#240.
