### PR TITLE
Improve link checking in Markcop

### DIFF
--- a/bin/markcop
+++ b/bin/markcop
@@ -152,11 +152,11 @@ function long_line {
 
 function missing_link {
   file_name="$1"
-  link_line_regex='[0-9]+:\[.*\]\(.*?(?=\))'
-  for line in $(echo "$2" | grep -oP $link_line_regex); do
+  link_line_regex='!?\[([^\]]*)\]\(([^)"]+)(?: \"([^\"]+)\")?\)'
+  for line in $(echo "$2" | grep -noP $link_line_regex); do
     line_num=$(echo $line | cut -f1)
     dir=$(dirname "$file_name")
-    link_dest=$(echo $line | grep -oP '\[.*\]\(\K.*')
+    link_dest=$(echo $line | sed 's/.*\[.*\](\(.*\))/\1/')
     broken_link=true
 
     # Only check if the link is not a URL and if it's not empty


### PR DESCRIPTION
Previously not all the links in the repo were being checked. This fixes that.
