### PR TITLE
Add ShareAlike to dictionary

### DIFF
--- a/lib/dictionary
+++ b/lib/dictionary
@@ -129,6 +129,7 @@ schoolers
 screenshot
 Selynna
 sethtrei
+ShareAlike
 Shoebridge
 should've
 signup


### PR DESCRIPTION
This pull request adds "ShareAlike", which is part of the name of the Creative Commons Attribution-ShareAlike 4.0 International license to Markcop's dictionary.

This needs to be merged before hackclub/hackclub#631 to fix its tests.
