### PR TITLE
Add "lowell" to dictionary

### DIFF
--- a/lib/dictionary
+++ b/lib/dictionary
@@ -84,6 +84,7 @@ LEDs
 Leung
 login
 Los
+lowell
 Ludum
 Markcop
 Mateo


### PR DESCRIPTION
This is to get hackclub/hackclub#635 passing. It has to be lowercase because it's part of a filename.
