### PR TITLE
Add spellings for personal website

### DIFF
--- a/lib/dictionary
+++ b/lib/dictionary
@@ -12,7 +12,6 @@ AIME
 Airbnb
 Airbnb's
 Airtable
-alice
 AMC
 analytics
 andreadeng

--- a/lib/dictionary
+++ b/lib/dictionary
@@ -12,6 +12,7 @@ AIME
 Airbnb
 Airbnb's
 Airtable
+alice
 AMC
 analytics
 andreadeng
@@ -24,6 +25,7 @@ Arduino
 Armijo
 Arys
 assignee
+autocomplete
 Avi
 backend
 backticks
@@ -47,6 +49,7 @@ cancelled
 CAPTCHA
 Carvey
 Cayley
+Cena's
 CEOs
 changemaking
 Chaoyi
@@ -156,6 +159,7 @@ hellyeah
 Hesby
 HH
 HN
+HTTPS
 Hubot
 Hubot's
 IDE
@@ -178,6 +182,7 @@ jonl
 jonleung
 jonleung's
 Jonwlee
+Jourard
 js
 JS
 jsbinctl
@@ -237,6 +242,7 @@ Minecraft
 MLH
 MMS
 mockup
+Modi
 mortem
 mortems
 Mucher
@@ -285,6 +291,7 @@ Preorders
 PRs
 PSAT
 PTTs
+Pushkar
 px
 que
 quo
@@ -292,10 +299,12 @@ radians
 Rafe
 Ralston
 Rampalli
+Ravago
 Ravenwood
 rd
 README
 READMEs
+Rebecca
 recused
 relatable
 repo
@@ -310,6 +319,7 @@ rollout
 Romanoff
 Rossmann
 Salman
+Schoen
 schooler
 schoolers
 screenshot
@@ -342,8 +352,8 @@ Sneha
 SOOOOOOOOOOOOOOOOOOOOOOOOO
 Sorto
 Sortos
-Sourcegraph
 SoundCloud
+Sourcegraph
 Soylent
 sponsorships
 spooky
@@ -359,6 +369,7 @@ Summiter
 Teagan
 TechCrunch
 Technorati
+techy
 TEDx
 TeenDev
 Tejas
@@ -421,6 +432,7 @@ workspace
 workspaces
 Yadaram
 YAML
+Yaron
 yay
 YC
 YouTube
@@ -431,5 +443,6 @@ zachlatta's
 Zain's
 Zencoder
 ZenHub
+Zhang
 Zhang
 Zulip


### PR DESCRIPTION
@jonleung made a commit for this already but apparently didn't submit a PR. I removed lowercase "alice" from the dictionary since alice1337 should have been in backquotes.
