### PR TITLE
Add Zha to dictionary

### DIFF
--- a/lib/dictionary
+++ b/lib/dictionary
@@ -442,6 +442,7 @@ zachlatta's
 Zain's
 Zencoder
 ZenHub
+Zha
 Zhang
 Zhang
 Zulip


### PR DESCRIPTION
Zha was missing from Jonathan's earlier commit to add spellings for the personal website workshop.
