### PR TITLE
Add FGL to dictionary

### DIFF
--- a/lib/dictionary
+++ b/lib/dictionary
@@ -112,6 +112,7 @@ Escapa
 etherpad
 ethnicities
 extracurriculars
+FGL
 filename
 financials
 Flappy


### PR DESCRIPTION
The Bigfoot workshop uses this in reference to https://FGL.com.
