### PR TITLE
Add words for Fast Forward application

### DIFF
--- a/lib/dictionary
+++ b/lib/dictionary
@@ -300,6 +300,7 @@ nguyenbrian
 nitty
 NodeJS
 nonexistant
+NYT
 octothorpe
 Octocat
 Oculus
@@ -500,6 +501,7 @@ workflow
 Workflowy
 workspace
 workspaces
+WSJ
 Xcode
 Yadaram
 YAML


### PR DESCRIPTION
- NYT = New York Times
- WSJ = Wall Street Journal
