### PR TITLE
Allow users to only run a subset of the available checks

### DIFF
--- a/bin/markcop
+++ b/bin/markcop
@@ -294,6 +294,30 @@ function run_check {
   $check "$file" "$content"
 }
 
+# Parse passed CLI options
+#
+# See https://stackoverflow.com/a/14203146 for where this code came from.
+while [[ "$#" -gt 1 ]]
+do
+  key="$1"
+
+  case "$key" in
+    # User can pass a comma separated list of check names to run a subset of the
+    # available checks.
+    -c|--checks)
+      # Split passed checks by comma and overwrite CHECKS array with them.
+      #
+      # See https://stackoverflow.com/a/10586169.
+      IFS="," read -r -a CHECKS <<< "$2"
+      shift
+      ;;
+    *)
+      # unknown option
+    ;;
+  esac
+  shift
+done
+
 # Run through each function in the CHECKS array, passing each $file and
 # $contents
 for check in "${CHECKS[@]}"; do


### PR DESCRIPTION
This pull request introduces the `--checks` option (also available as `-c`), which allows users to pass in a comma separated list of checks to run.

While integrating Markcop with a personal project, I ran into an issue where I only cared about the `missing_link` check. `spellcheck` was breaking the build because I had words that weren't in Markcop's dictionary and it didn't make sense to add them.

Example usage:

```
$ markcop --checks trailing_whitespace,missing_link,eof_newline
$ markcop -c eof_newline
$ markcop -c trailing_whitespace,malformed_header README.md
```

Docs explaining usage should be added to `README.md` after #133 gets merged.